### PR TITLE
add word-break for text in public profile page

### DIFF
--- a/src/features/public-profile/ui/public-profile-data/public-profile-data.module.scss
+++ b/src/features/public-profile/ui/public-profile-data/public-profile-data.module.scss
@@ -65,6 +65,7 @@
 .fullText {
   max-width: 100%;
   white-space: pre-wrap;
+  word-break: break-all;
 }
 
 .showMore {


### PR DESCRIPTION
add word-break to fit the layout of the public profile page within the profile info container