### PR TITLE
fix public profile info height

### DIFF
--- a/src/entities/profile-following/ui/profile-following.module.scss
+++ b/src/entities/profile-following/ui/profile-following.module.scss
@@ -1,7 +1,6 @@
 @import '@/shared/styles/media-queries';
 
 .subscribersContainer {
-  margin-top: 1.1875rem;
   @include media-s-medium {
     gap: 58px;
   }

--- a/src/features/public-profile/ui/public-profile-data/public-profile-data.module.scss
+++ b/src/features/public-profile/ui/public-profile-data/public-profile-data.module.scss
@@ -3,6 +3,7 @@
 .profileContainer {
   display: flex;
   margin-bottom: 3rem;
+  max-height: 12.75rem;
 
   .avatarContainer {
     grid-area: avatar;
@@ -18,9 +19,8 @@
   .profileDataContainer{
     display: flex;
     flex-direction: column;
-    gap: 1.5rem;
+    gap: 1.4375rem;
     margin-left: 2.5rem;
-
   }
 }
 


### PR DESCRIPTION
![image](https://github.com/beamle/inctagram/assets/138142439/60211304-fe74-448d-ba2f-5ac555d566cc)
fixed the max height of the public page profile info and removed margin for the gap prop to properly layout the info inside (before that the size of the container was changing in case the show more link was pressed and the full text 'about user' was shown, moving the whole content downwards)