### PR TITLE
fixed current-subscriptions url

### DIFF
--- a/src/shared/api/services/subscriptions/subscriptions.api.ts
+++ b/src/shared/api/services/subscriptions/subscriptions.api.ts
@@ -36,7 +36,7 @@ export const subscriptionsApi = createApi({
             headers: {
               Authorization: `Bearer ${localStorage.getItem('accessToken') as string}`,
             },
-            url: `subscriptions/current-subscriptions`,
+            url: `subscriptions/current-payment-subscriptions`,
             method: 'GET',
           }
         },


### PR DESCRIPTION
В связи с тем, что изменился url в api для current-subscriptions, перестали поступать данные для вкладки Управление Профиля пользователя, в том числе дата окончания текущей подписки и флажок Auto-Renewal